### PR TITLE
Add dark theme toggle

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -7,17 +7,36 @@
 .app-header {
   text-align: center;
   margin-bottom: 2.5rem;
+  position: relative;
 }
 
 .app-header h1 {
   font-size: 2.5rem;
-  color: #0d5c8a;
+  color: var(--heading-color);
 }
 
 .app-header p {
   margin-top: 0.5rem;
-  color: #4a6d85;
+  color: var(--subtext-color);
   font-size: 1.05rem;
+}
+
+.theme-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: var(--toggle-bg);
+  border: 1.5px solid var(--toggle-border);
+  border-radius: 8px;
+  padding: 0.4rem 0.7rem;
+  font-size: 1.25rem;
+  cursor: pointer;
+  line-height: 1;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.theme-toggle:hover {
+  border-color: var(--heading-color);
 }
 
 .app-main {
@@ -34,15 +53,16 @@
 
 /* List card */
 .list-card {
-  background: #fff;
+  background: var(--card-bg);
   border-radius: 12px;
   padding: 1.5rem;
-  box-shadow: 0 2px 12px rgba(13, 92, 138, 0.1);
+  box-shadow: 0 2px 12px var(--card-shadow);
+  transition: background 0.3s, box-shadow 0.3s;
 }
 
 .list-card h2 {
   font-size: 1.3rem;
-  color: #0d5c8a;
+  color: var(--heading-color);
   margin-bottom: 1rem;
 }
 
@@ -56,20 +76,22 @@
 .add-form input {
   flex: 1;
   padding: 0.5rem 0.75rem;
-  border: 1.5px solid #b0cfe0;
+  border: 1.5px solid var(--input-border);
   border-radius: 8px;
   font-size: 0.95rem;
   outline: none;
-  transition: border-color 0.2s;
+  background: var(--input-bg);
+  color: var(--input-text);
+  transition: border-color 0.2s, background 0.3s, color 0.3s;
 }
 
 .add-form input:focus {
-  border-color: #0d5c8a;
+  border-color: var(--input-focus-border);
 }
 
 .add-form button {
   padding: 0.5rem 1rem;
-  background: #0d5c8a;
+  background: var(--btn-bg);
   color: #fff;
   border: none;
   border-radius: 8px;
@@ -79,7 +101,7 @@
 }
 
 .add-form button:hover {
-  background: #0a4a70;
+  background: var(--btn-hover-bg);
 }
 
 /* Item list */
@@ -95,15 +117,16 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.5rem 0.75rem;
-  background: #f0f8ff;
+  background: var(--item-row-bg);
   border-radius: 8px;
   font-size: 0.95rem;
+  transition: background 0.3s;
 }
 
 .delete-btn {
   background: transparent;
   border: none;
-  color: #c0392b;
+  color: var(--delete-color);
   cursor: pointer;
   font-size: 0.85rem;
   padding: 0 0.25rem;
@@ -112,23 +135,24 @@
 }
 
 .delete-btn:hover {
-  color: #922b21;
+  color: var(--delete-hover-color);
 }
 
 .empty-hint {
-  color: #7f9ab0;
+  color: var(--empty-hint-color);
   font-size: 0.9rem;
   font-style: italic;
 }
 
 /* Error banner */
 .error-banner {
-  background: #fdecea;
-  color: #c0392b;
-  border: 1px solid #f5c6c2;
+  background: var(--error-bg);
+  color: var(--error-color);
+  border: 1px solid var(--error-border);
   border-radius: 8px;
   padding: 0.75rem 1rem;
   margin-bottom: 1.25rem;
   font-size: 0.95rem;
   text-align: center;
+  transition: background 0.3s, color 0.3s, border-color 0.3s;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,14 @@ function App() {
   const [fishes, setFishes] = useState([]);
   const [places, setPlaces] = useState([]);
   const [error, setError] = useState(null);
+  const [darkMode, setDarkMode] = useState(() => {
+    return localStorage.getItem('theme') === 'dark';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', darkMode ? 'dark' : 'light');
+    localStorage.setItem('theme', darkMode ? 'dark' : 'light');
+  }, [darkMode]);
 
   function showError(msg) {
     setError(msg);
@@ -80,6 +88,14 @@ function App() {
       <header className="app-header">
         <h1>🎣 ToFish</h1>
         <p>Track the fish you want to catch and the places you want to fish.</p>
+        <button
+          className="theme-toggle"
+          onClick={() => setDarkMode((prev) => !prev)}
+          aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+          title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+        >
+          {darkMode ? '☀️' : '🌙'}
+        </button>
       </header>
       <main className="app-main">
         <ItemList

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,9 +4,58 @@
   padding: 0;
 }
 
+:root {
+  --bg-body: #e8f4f8;
+  --text-body: #1a2e3b;
+  --heading-color: #0d5c8a;
+  --subtext-color: #4a6d85;
+  --card-bg: #fff;
+  --card-shadow: rgba(13, 92, 138, 0.1);
+  --input-border: #b0cfe0;
+  --input-focus-border: #0d5c8a;
+  --btn-bg: #0d5c8a;
+  --btn-hover-bg: #0a4a70;
+  --item-row-bg: #f0f8ff;
+  --delete-color: #c0392b;
+  --delete-hover-color: #922b21;
+  --empty-hint-color: #7f9ab0;
+  --error-bg: #fdecea;
+  --error-color: #c0392b;
+  --error-border: #f5c6c2;
+  --toggle-bg: transparent;
+  --toggle-border: #b0cfe0;
+  --input-bg: #fff;
+  --input-text: #1a2e3b;
+}
+
+[data-theme="dark"] {
+  --bg-body: #121a21;
+  --text-body: #d0dce5;
+  --heading-color: #5eb8e4;
+  --subtext-color: #8badc4;
+  --card-bg: #1a2630;
+  --card-shadow: rgba(0, 0, 0, 0.3);
+  --input-border: #2e4457;
+  --input-focus-border: #5eb8e4;
+  --btn-bg: #1a6d9e;
+  --btn-hover-bg: #2080b8;
+  --item-row-bg: #1e2f3d;
+  --delete-color: #e57373;
+  --delete-hover-color: #ef5350;
+  --empty-hint-color: #6a8da6;
+  --error-bg: #3a1a1a;
+  --error-color: #e57373;
+  --error-border: #5a2a2a;
+  --toggle-bg: #1a2630;
+  --toggle-border: #2e4457;
+  --input-bg: #162029;
+  --input-text: #d0dce5;
+}
+
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background: #e8f4f8;
-  color: #1a2e3b;
+  background: var(--bg-body);
+  color: var(--text-body);
   min-height: 100vh;
+  transition: background 0.3s, color 0.3s;
 }


### PR DESCRIPTION
## Summary
- Adds a dark/light theme toggle button in the app header
- Uses CSS custom properties for all theme colors, switched via `[data-theme="dark"]` on the root element
- Persists user's theme preference in `localStorage`

## Changes
- `frontend/src/index.css`: Added CSS custom properties for light and dark themes
- `frontend/src/App.css`: Updated all hardcoded colors to use CSS variables; added `.theme-toggle` styles
- `frontend/src/App.jsx`: Added `darkMode` state with `localStorage` persistence and a toggle button

Closes #4

## Test plan
- [ ] Verify the toggle button appears in the header
- [ ] Click the toggle and confirm all colors switch to dark theme
- [ ] Refresh the page and confirm the theme preference is preserved
- [ ] Switch back to light mode and confirm it works

Generated with [Claude Code](https://claude.com/claude-code)